### PR TITLE
fix: settle-up why-trail honesty + member balances at a glance

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -300,7 +300,8 @@
     "notYoursHint": "This one is {name}'s to pay. Record it here only if they already have.",
     "whyFor": "Why does {from} pay {to}?",
     "trailEmpty": "No expenses behind this one yet.",
-    "trailShare": "{name}'s share"
+    "trailShare": "{name}'s share",
+    "trailSimplified": "This payment settles the group's overall balances and may not match these expenses exactly."
   },
   "profile": {
     "displayName": "Display name",

--- a/src/client/components/WhyTrail.test.ts
+++ b/src/client/components/WhyTrail.test.ts
@@ -1,0 +1,84 @@
+// Pure logic behind the "why?" disclosure. See WhyTrail.tsx for why
+// fullyExplained matters: a simplified transfer can have a direct trail
+// that doesn't sum to the transfer amount, and the UI must say so rather
+// than imply completeness.
+import { describe, expect, it } from "vitest";
+import { directTrail, directTrailNet } from "./WhyTrail";
+
+const FROM = "m-from";
+const TO = "m-to";
+
+function expense(payerMemberId: string, splits: Array<{ memberId: string; amount: number }>, paidAt = 1) {
+  return { id: `e-${paidAt}-${payerMemberId}`, payerMemberId, description: "x", paidAt, splits };
+}
+
+describe("directTrail", () => {
+  it("to paid, from has a split: one row, net is negative (from owes)", () => {
+    const rows = directTrail(
+      [expense(TO, [{ memberId: FROM, amount: 200_00 }])],
+      FROM,
+      TO,
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.paidByTo).toBe(true);
+    expect(directTrailNet(rows)).toBe(-200_00);
+  });
+
+  it("from paid, to has a split: one row, net is positive (to owes from)", () => {
+    const rows = directTrail(
+      [expense(FROM, [{ memberId: TO, amount: 150_00 }])],
+      FROM,
+      TO,
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.paidByTo).toBe(false);
+    expect(directTrailNet(rows)).toBe(150_00);
+  });
+
+  it("both directions present: net is the correct sum, not just one side", () => {
+    const rows = directTrail(
+      [
+        expense(TO, [{ memberId: FROM, amount: 200_00 }], 1),
+        expense(FROM, [{ memberId: TO, amount: 150_00 }], 2),
+      ],
+      FROM,
+      TO,
+    );
+    expect(rows).toHaveLength(2);
+    expect(directTrailNet(rows)).toBe(150_00 - 200_00);
+  });
+
+  it("no shared expenses: empty trail, zero net", () => {
+    const rows = directTrail(
+      [expense("someone-else", [{ memberId: "another", amount: 100_00 }])],
+      FROM,
+      TO,
+    );
+    expect(rows).toEqual([]);
+    expect(directTrailNet(rows)).toBe(0);
+  });
+
+  it("fullyExplained: net exactly matches -amount at the integer paise boundary", () => {
+    const rows = directTrail(
+      [expense(TO, [{ memberId: FROM, amount: 640_00 }])],
+      FROM,
+      TO,
+    );
+    const net = directTrailNet(rows);
+    const amount = 640_00;
+    const fullyExplained = rows.length > 0 && -net === amount;
+    expect(fullyExplained).toBe(true);
+  });
+
+  it("simplified/partial: rows exist but net doesn't cover the transfer amount", () => {
+    const rows = directTrail(
+      [expense(TO, [{ memberId: FROM, amount: 200_00 }])],
+      FROM,
+      TO,
+    );
+    const net = directTrailNet(rows);
+    const amount = 640_00;
+    const fullyExplained = rows.length > 0 && -net === amount;
+    expect(fullyExplained).toBe(false);
+  });
+});

--- a/src/client/components/WhyTrail.tsx
+++ b/src/client/components/WhyTrail.tsx
@@ -3,6 +3,12 @@
 // simplification reliably produces.
 //
 // <details> is keyboard reachable and announced as a disclosure with no JS.
+//
+// transferPlan() is a greedy net-position simplification (src/server/balances.ts):
+// a suggested transfer can legitimately be between two people who share zero
+// direct expenses. The direct-expense list below is real and correctly netted,
+// but for a multi-hop simplification it is not the whole story - see
+// `fullyExplained` and settle.trailSimplified.
 import { Amount } from "~/client/components/ui";
 import { focusRing } from "~/client/components/ui/focus";
 import { useExpenses, useMembers } from "~/client/lib/queries";
@@ -10,14 +16,55 @@ import { t } from "~/client/i18n";
 
 const day = new Intl.DateTimeFormat("en-IN", { day: "numeric", month: "short" });
 
+export type TrailRow = {
+  expenseId: string;
+  description: string;
+  paidAt: number;
+  paidByTo: boolean;
+  share: number; // paise, unsigned
+};
+
+export function directTrail(
+  expenses: Array<{
+    id: string;
+    payerMemberId: string;
+    description: string;
+    paidAt: number;
+    splits: Array<{ memberId: string; amount: number }>;
+  }>,
+  fromMemberId: string,
+  toMemberId: string,
+): TrailRow[] {
+  return expenses
+    .filter(
+      (e) =>
+        (e.payerMemberId === toMemberId && e.splits.some((s) => s.memberId === fromMemberId)) ||
+        (e.payerMemberId === fromMemberId && e.splits.some((s) => s.memberId === toMemberId)),
+    )
+    .map((e) => {
+      const paidByTo = e.payerMemberId === toMemberId;
+      const share = e.splits.find((s) => s.memberId === (paidByTo ? fromMemberId : toMemberId))?.amount ?? 0;
+      return { expenseId: e.id, description: e.description, paidAt: e.paidAt, paidByTo, share };
+    })
+    .sort((a, b) => b.paidAt - a.paidAt);
+}
+
+/** Net signed paise the direct trail accounts for, from `from`'s side
+ *  (negative = from owes it, matching `Amount`'s sign convention elsewhere). */
+export function directTrailNet(rows: TrailRow[]): number {
+  return rows.reduce((sum, r) => sum + (r.paidByTo ? -r.share : r.share), 0);
+}
+
 export function WhyTrail({
   ledgerId,
   fromMemberId,
   toMemberId,
+  amount,
 }: {
   ledgerId: string;
   fromMemberId: string;
   toMemberId: string;
+  amount: number;
 }) {
   // ponytail: both queries are already cached per ledger by TanStack Query, so a
   // trail per transfer row costs one fetch, not N.
@@ -25,13 +72,9 @@ export function WhyTrail({
   const members = useMembers(ledgerId);
   const name = (id: string) => (members.data ?? []).find((m) => m.id === id)?.nickname ?? t("member.unknown");
 
-  const rows = (expenses.data ?? [])
-    .filter(
-      (e) =>
-        (e.payerMemberId === toMemberId && e.splits.some((s) => s.memberId === fromMemberId)) ||
-        (e.payerMemberId === fromMemberId && e.splits.some((s) => s.memberId === toMemberId)),
-    )
-    .sort((a, b) => b.paidAt - a.paidAt);
+  const rows = directTrail(expenses.data ?? [], fromMemberId, toMemberId);
+  const net = directTrailNet(rows);
+  const fullyExplained = rows.length > 0 && -net === amount;
 
   return (
     <details className="mt-1">
@@ -44,33 +87,36 @@ export function WhyTrail({
       </summary>
       {rows.length === 0 ? (
         <p className="py-2 text-[12px]" style={{ color: "var(--ink-3)" }}>
-          {t("settle.trailEmpty")}
+          {t("settle.trailSimplified")}
         </p>
       ) : (
-        <ul className="mt-1 mb-1">
-          {rows.map((e) => {
-            const paidByTo = e.payerMemberId === toMemberId;
-            const share = e.splits.find((s) => s.memberId === (paidByTo ? fromMemberId : toMemberId))?.amount ?? 0;
-            return (
-              <li key={e.id} className="flex items-center justify-between gap-3 border-b py-1.5 last:border-b-0" style={{ borderColor: "var(--line)" }}>
+        <>
+          <ul className="mt-1 mb-1">
+            {rows.map((r) => (
+              <li key={r.expenseId} className="flex items-center justify-between gap-3 border-b py-1.5 last:border-b-0" style={{ borderColor: "var(--line)" }}>
                 <span className="min-w-0 flex-1">
-                  <span className="block truncate text-[13px]">{e.description}</span>
+                  <span className="block truncate text-[13px]">{r.description}</span>
                   <span className="block text-[11px]" style={{ color: "var(--ink-3)" }}>
-                    {day.format(e.paidAt)} · {t("expense.paidByName", { name: name(e.payerMemberId) })}
+                    {day.format(r.paidAt)} · {t("expense.paidByName", { name: name(r.paidByTo ? toMemberId : fromMemberId) })}
                   </span>
                 </span>
                 {/* Sign is from the payer-of-the-transfer's side: negative = they owe
                     it. `subject` makes the spoken direction match - this is never the
                     viewer's own balance. */}
                 <Amount
-                  paise={paidByTo ? -share : share}
+                  paise={r.paidByTo ? -r.share : r.share}
                   label={t("settle.trailShare", { name: name(fromMemberId) })}
                   subject={name(fromMemberId)}
                 />
               </li>
-            );
-          })}
-        </ul>
+            ))}
+          </ul>
+          {!fullyExplained && (
+            <p className="py-2 text-[12px]" style={{ color: "var(--ink-3)" }}>
+              {t("settle.trailSimplified")}
+            </p>
+          )}
+        </>
       )}
     </details>
   );

--- a/src/client/routes/BalancesTab.tsx
+++ b/src/client/routes/BalancesTab.tsx
@@ -176,7 +176,7 @@ function LedgerPlan({ ledger, onLegs }: { ledger: LedgerSummary; onLegs: (id: st
                 </span>
                 <Amount paise={tr.amount} label={t("settle.suggested")} tone="neutral" />
               </div>
-              <WhyTrail ledgerId={ledger.id} fromMemberId={tr.fromMemberId} toMemberId={tr.toMemberId} />
+              <WhyTrail ledgerId={ledger.id} fromMemberId={tr.fromMemberId} toMemberId={tr.toMemberId} amount={tr.amount} />
             </div>
           ))
         )}

--- a/src/client/routes/LedgerDetail.tsx
+++ b/src/client/routes/LedgerDetail.tsx
@@ -7,6 +7,7 @@ import { ExpenseSheet } from "~/client/components/ExpenseSheet";
 import { LedgerMenu } from "~/client/components/LedgerMenu";
 import { BurnRate, runFor } from "~/client/routes/LedgersTab";
 import {
+  useBalances,
   useCategories,
   useExpenseSearch,
   useExpenses,
@@ -108,6 +109,7 @@ export function LedgerDetail() {
   const navigate = useNavigate();
   const ledger = useLedger(ledgerId);
   const members = useMembers(ledgerId);
+  const balances = useBalances(ledgerId);
   const categories = useCategories();
   const me = useMe();
 
@@ -366,17 +368,27 @@ export function LedgerDetail() {
         {t("ledger.members")}
       </div>
       <div className="rounded-[7px] border px-3.5 py-2" style={{ background: "var(--paper-2)", borderColor: "var(--line)" }}>
-        {(members.data ?? []).map((m) => (
-          <div key={m.id} className="flex items-center gap-2.5 py-1.5">
-            <Avatar name={m.nickname} />
-            <span className="flex-1 truncate text-[14px]">{m.nickname}</span>
-            {m.guestName !== null && (
-              <span className="text-[11.5px]" style={{ color: "var(--ink-3)" }}>
-                {t("member.guest")}
-              </span>
-            )}
-          </div>
-        ))}
+        {(members.data ?? []).map((m) => {
+          const position = (balances.data?.positions ?? []).find((p) => p.memberId === m.id);
+          return (
+            <div key={m.id} className="flex items-center gap-2.5 py-1.5">
+              <Avatar name={m.nickname} />
+              <span className="flex-1 truncate text-[14px]">{m.nickname}</span>
+              {m.guestName !== null && (
+                <span className="text-[11.5px]" style={{ color: "var(--ink-3)" }}>
+                  {t("member.guest")}
+                </span>
+              )}
+              {position && (
+                <Amount
+                  paise={position.net}
+                  label={t("ledger.netPosition")}
+                  subject={m.id === myMemberId ? undefined : m.nickname}
+                />
+              )}
+            </div>
+          );
+        })}
       </div>
 
       {selected && (

--- a/src/client/routes/LedgerDetail.tsx
+++ b/src/client/routes/LedgerDetail.tsx
@@ -174,6 +174,33 @@ export function LedgerDetail() {
         <BurnRate ledger={ledger.data} />
       </div>
 
+      <div className="mx-0.5 mt-5 mb-2 text-[10.5px] tracking-[0.13em] uppercase" style={{ color: "var(--ink-3)" }}>
+        {t("ledger.members")}
+      </div>
+      <div className="rounded-[7px] border px-3.5 py-2" style={{ background: "var(--paper-2)", borderColor: "var(--line)" }}>
+        {(members.data ?? []).map((m) => {
+          const position = (balances.data?.positions ?? []).find((p) => p.memberId === m.id);
+          return (
+            <div key={m.id} className="flex items-center gap-2.5 py-1.5">
+              <Avatar name={m.nickname} />
+              <span className="flex-1 truncate text-[14px]">{m.nickname}</span>
+              {m.guestName !== null && (
+                <span className="text-[11.5px]" style={{ color: "var(--ink-3)" }}>
+                  {t("member.guest")}
+                </span>
+              )}
+              {position && (
+                <Amount
+                  paise={position.net}
+                  label={t("ledger.netPosition")}
+                  subject={m.id === myMemberId ? undefined : m.nickname}
+                />
+              )}
+            </div>
+          );
+        })}
+      </div>
+
       <Sheet open={adding} onOpenChange={setAdding} title={t("expense.add")}>
         <Suspense fallback={null}>
           <ExpenseForm onDone={() => setAdding(false)} />
@@ -363,33 +390,6 @@ export function LedgerDetail() {
           />
         ))
       )}
-
-      <div className="mx-0.5 mt-5 mb-2 text-[10.5px] tracking-[0.13em] uppercase" style={{ color: "var(--ink-3)" }}>
-        {t("ledger.members")}
-      </div>
-      <div className="rounded-[7px] border px-3.5 py-2" style={{ background: "var(--paper-2)", borderColor: "var(--line)" }}>
-        {(members.data ?? []).map((m) => {
-          const position = (balances.data?.positions ?? []).find((p) => p.memberId === m.id);
-          return (
-            <div key={m.id} className="flex items-center gap-2.5 py-1.5">
-              <Avatar name={m.nickname} />
-              <span className="flex-1 truncate text-[14px]">{m.nickname}</span>
-              {m.guestName !== null && (
-                <span className="text-[11.5px]" style={{ color: "var(--ink-3)" }}>
-                  {t("member.guest")}
-                </span>
-              )}
-              {position && (
-                <Amount
-                  paise={position.net}
-                  label={t("ledger.netPosition")}
-                  subject={m.id === myMemberId ? undefined : m.nickname}
-                />
-              )}
-            </div>
-          );
-        })}
-      </div>
 
       {selected && (
         <ExpenseSheet

--- a/src/client/routes/LedgerDetail.tsx
+++ b/src/client/routes/LedgerDetail.tsx
@@ -165,7 +165,11 @@ export function LedgerDetail() {
             <Button size="sm" onClick={() => setAdding(true)}>
               {t("expense.add")}
             </Button>
-            <Button size="sm" variant="ghost" onClick={() => navigate(`/ledgers/${ledgerId}/settle`)}>
+            <Button
+              size="sm"
+              variant={ledger.data.net === 0 ? "ghost" : "primary"}
+              onClick={() => navigate(`/ledgers/${ledgerId}/settle`)}
+            >
               {t("settle.title")}
             </Button>
           </span>

--- a/src/client/routes/SettleUp.tsx
+++ b/src/client/routes/SettleUp.tsx
@@ -185,7 +185,7 @@ export default function SettleUp() {
                 </p>
               )}
               {owedToMe && <Nudge ledgerId={ledgerId} toUserId={member(tr.fromMemberId)?.userId ?? null} />}
-              <WhyTrail ledgerId={ledgerId} fromMemberId={tr.fromMemberId} toMemberId={tr.toMemberId} />
+              <WhyTrail ledgerId={ledgerId} fromMemberId={tr.fromMemberId} toMemberId={tr.toMemberId} amount={tr.amount} />
             </div>
           );
         })


### PR DESCRIPTION
## Summary
- Settle-up's "why?" trail no longer implies false completeness: a simplified/multi-hop transfer now says plainly when the direct-expense list doesn't fully explain the amount, instead of silently not adding up (#47)
- Ledger members list now shows each person's net position (owed/owes) at a glance (#48)
- Members block moved above the expense list/search/filters on the ledger detail page (#49)
- Settle Up button is now primary-styled when there's an outstanding balance, ghost when already settled (#50)

Closes #47, #48, #49, #50

## Test plan
- [x] `pnpm build` — clean
- [x] `pnpm test` — 467/467 pass, including new `WhyTrail.test.ts` covering the `fullyExplained` boundary
- [x] `pnpm typecheck` — clean (verified per-plan in isolated worktrees before merge)